### PR TITLE
Save highest ex level of unit and auto select it in the builder.

### DIFF
--- a/static/builder.js
+++ b/static/builder.js
@@ -1641,7 +1641,9 @@ function updateUnitLevelDisplay() {
             if (builds[currentUnitIndex]._exAwakeningLevel > -1) {
                 $("#unitExAwakeningLevel select").val(builds[currentUnitIndex]._exAwakeningLevel.toString());
             } else {
-                const exRank = actuallyOwnedUnits[builds[currentUnitIndex].unit.id]?.exRank ?? 1;
+                // See if they own the unit. We need to look for both the current unit as well as the braveshift to handle the case where they start with the braveshifted unit.
+                const ownedUnit = actuallyOwnedUnits[builds[currentUnitIndex].unit.id] ?? actuallyOwnedUnits[builds[currentUnitIndex].getBraveshift().unit.id];
+                const exRank = ownedUnit?.exRank ?? 1;
                 $("#unitExAwakeningLevel select").val(exRank.toString());
                 builds[currentUnitIndex].setExAwakeningLevel(exRank);
             }

--- a/static/builder.js
+++ b/static/builder.js
@@ -1641,8 +1641,9 @@ function updateUnitLevelDisplay() {
             if (builds[currentUnitIndex]._exAwakeningLevel > -1) {
                 $("#unitExAwakeningLevel select").val(builds[currentUnitIndex]._exAwakeningLevel.toString());
             } else {
-                $("#unitExAwakeningLevel select").val("1");
-                builds[currentUnitIndex].setExAwakeningLevel(1);
+                const exRank = actuallyOwnedUnits[builds[currentUnitIndex].unit.id]?.exRank ?? 1;
+                $("#unitExAwakeningLevel select").val(exRank.toString());
+                builds[currentUnitIndex].setExAwakeningLevel(exRank);
             }
         } else {
             $("#unitExAwakeningLevel").addClass("hidden");

--- a/static/builder/unitBuild.js
+++ b/static/builder/unitBuild.js
@@ -386,6 +386,10 @@ class UnitBuild {
         this._braveShift = unitShift;
     }
 
+    getBraveshift() {
+        return this._braveShift;
+    }
+
     hasBraveShift() {
         return this._braveShift !== null;
     }

--- a/static/common.js
+++ b/static/common.js
@@ -3,6 +3,7 @@ var wikiBaseUrl = "https://exvius.fandom.com/";
 var data;
 var units;
 var ownedUnits;
+var actuallyOwnedUnits;
 var itemInventory;
 var ownedEspers;
 var ownedConsumables;
@@ -2652,6 +2653,7 @@ $(function() {
         });
         $.get(server + '/units', function(result) {
             ownedUnits = result;
+            actuallyOwnedUnits = result;
             if (result.version && result.version == 3) {
                 getStaticData("units", false, function(allUnitResult) {
                     for (var unitSerieId in allUnitResult) {

--- a/static/units.js
+++ b/static/units.js
@@ -748,6 +748,10 @@ function awakenFollowUp(unitId) {
     markSaveNeeded();
 }
 
+function clamp(value, minValue, maxValue) {
+    return Math.max(minValue, Math.min(maxValue, value));
+}
+
 function editUnit(unitId) {
     
     if (!ownedUnits[unitId]) {
@@ -793,6 +797,10 @@ function editUnit(unitId) {
             '<label for="ownedFragmentNumber">Owned Fragment number</label>' +
             '<input type="number" class="form-control" id="ownedFragmentNumber" placeholder="Enter owned number" value="' + (ownedConsumables[unit.fragmentId] || 0) + '" step="5">' +
             '</div>';
+        form += '<div class="form-group">' +
+            '<label for="exRank">EX Level</label>' +
+            '<input type="number" class="form-control" id="exRank" placeholder="Enter highest ex rank" value="' + (ownedUnits[unitId].exRank ?? 0) + '">' +
+            '</div>';
     }
 
 
@@ -819,6 +827,8 @@ function editUnit(unitId) {
                             if (unit.fragmentId) {
                                 ownedConsumables[unit.fragmentId] = parseInt($("#ownedFragmentNumber").val() || 0);
                             }
+                            const exRankString = $("#exRank").val();
+                            ownedUnits[unitId].exRank = exRankString ? clamp(parseInt(exRankString), 0, 3) : undefined;
                         }
                         if (unit.max_rarity == '7' || (unit.max_rarity == 'NV' && unit.min_rarity != 'NV')) {
                             ownedUnits[unitId].sevenStar = parseInt($("#ownedSeventStarNumber").val() || 0);

--- a/static/units.js
+++ b/static/units.js
@@ -1300,7 +1300,7 @@ function treatImportFile(evt) {
                             return;
                         } else {
                             if (!importedOwnedUnit[baseUnitId]) {
-                                importedOwnedUnit[baseUnitId] = {"number":0,"farmable":0,"sevenStar":0,"farmableStmr":0};
+                                importedOwnedUnit[baseUnitId] = {"number":0,"farmable":0,"sevenStar":0,"farmableStmr":0,"exRank":0};
                             }
                             if (unit.tmr < 1000) {
                                 importedOwnedUnit[baseUnitId].farmable++;
@@ -1313,6 +1313,8 @@ function treatImportFile(evt) {
                                 if (unit.stmr < 1000) {
                                     importedOwnedUnit[baseUnitId].farmableStmr++;
                                 }
+                                // Store the max awakened ex level of this unit.
+                                importedOwnedUnit[baseUnitId].exRank = Math.max(importedOwnedUnit[baseUnitId].exRank, unit.exRank);
                             } else if (unit.id.endsWith("7")) { // Seven star units
                                 importedOwnedUnit[baseUnitId].sevenStar++;
                                 if (unit.stmr < 1000) {


### PR DESCRIPTION
Save the exRank field during import with the user's owned units.
When a unit is selected in the builder, use the it's ex level by default instead of always selecting 1. If the unit isn't owned or the rank is not available (say because they haven't imported their units after this change) it will still default to 1.